### PR TITLE
v0.1.2: fix render mode initialization from vscode configuration

### DIFF
--- a/media/viewer.js
+++ b/media/viewer.js
@@ -113,6 +113,14 @@ class Viewer {
           child.depth_material = new THREE.MeshDepthMaterial({
             side: this.params.doubleSide ? THREE.DoubleSide : THREE.FrontSide,
           });
+          // render mode initialization
+          if (this.params.renderMode === 'normal') {
+            child.material = child.normal_material;
+          } else if (this.params.renderMode === 'depth') {
+            child.material = child.depth_material;
+          } else {
+            child.material = child.color_material;
+          }
           // update stats
           this.num_meshes++;
           this.num_vertices += child.geometry.attributes.position.count; // this is always num_faces * 3...

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "kiui",
   "displayName": "mesh-viewer",
   "description": "VS Code 3D Mesh Viewer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "logo.webp",
   "homepage": "https://github.com/ashawkey/vscode-mesh-viewer",
   "repository": {


### PR DESCRIPTION
Description: This PR fixes an issue where the mesh viewer's initial render mode doesn't respect the `meshviewer.renderMode` setting from VSCode's configuration, always defaulting to 'color' mode regardless of the setting value.

**Current Issue:**
- The mesh viewer always initializes in 'color' render mode
- Setting `meshviewer.renderMode` to 'normal' or 'depth' in VSCode settings has no effect
- Render mode changes only work through GUI interactions

**Root Cause:**
- The render mode switching logic was only implemented in the GUI's onChange event handler
- Although `this.params.renderMode` correctly receives the configuration value, it wasn't applied during initialization
- Missing initialization step to set the correct material based on the configured render mode

**Solution:**
- Added proper initialization of render mode after material setup
- Applied the configured `this.params.renderMode` value during initial material creation
- Maintained existing GUI-based material switching logic for runtime changes

**Tests:**
- Users can now set render mode to normal (the depth material operates in the same manner) through VSCode settings:
  ```json
  {
    "meshviewer.renderMode": "normal"
  }
  ```
